### PR TITLE
Add community list link to FAQ

### DIFF
--- a/index.html
+++ b/index.html
@@ -272,7 +272,7 @@
 			So the <a href="http://phdcomics.com/comics.php?f=562">author list</a> of academic papers does not represent <a href="https://imgur.com/a/mKnnu">division of work</a> :)</p>
 			
 			<h3>Is my device vulnerable?</h3>
-			<p>Probably. Any device that uses Wi-Fi is likely vulnerable. Contact your vendor for more information.</p>
+			<p>Probably. Any device that uses Wi-Fi is likely vulnerable. Contact your vendor for more information or reference this <a href="https://github.com/kristate/krackinfo">community maintained list on GitHub</a>.</p>
 			
 			<h3>What if there are no security updates for my router?</h3>
 			<!-- Note: there might be implementations bugs where replay of msg4/4 causes a key reinstallation attack -->


### PR DESCRIPTION
We are developing a community driven list on GitHub -- a link for visibility would be appreciated.

Thanks!